### PR TITLE
Allow specifying session geometry (closes #85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - 1.6.0
+- Added `--geometry` parameter to `alces session start` command (#85)
 
 ## [1.5.0] - 2016-05-15
 

--- a/etc/session.rc
+++ b/etc/session.rc
@@ -41,3 +41,7 @@
 # Time in seconds between showing session timeout message and
 # performing the termination (default: 30).
 #cw_SESSION_termination_grace=30
+
+# Default geometry to use for sessions if user does not specify a geometry
+# (default: VNC server's default).
+#cw_SESSION_geometry="1024x768"

--- a/lib/functions/vnc.functions.sh
+++ b/lib/functions/vnc.functions.sh
@@ -51,25 +51,28 @@ vnc_create_password_file() {
 }
 
 vnc_session_start() {
-    local password sessiondir
+    local password geometry sessiondir
     password="$1"
-    sessiondir="$2"
-    shift 2
+    geometry="$2"
+    sessiondir="$3"
+    shift 3
 
     vnc_create_password_file "${password}" "${sessiondir}"
-    vnc_start_server "${sessiondir}" "$@"
+    vnc_start_server "${geometry}" "${sessiondir}" "$@"
 }
 
 vnc_start_server() {
-    local sessiondir
-    sessiondir="$1"
-    shift
+    local geometry sessiondir
+    geometry="$1"
+    sessiondir="$2"
+    shift 2
 
     $cw_VNC_VNCSERVER -autokill \
         -sessiondir "${sessiondir}" \
         -sessionscript "${sessiondir}/session.sh" \
         -vncpasswd "${sessiondir}/password.dat" \
         -exedir "${cw_VNC_BINDIR}" \
+        -geometry "${geometry}" \
         "$@" 2>"${sessiondir}/vncserver.err" > "${sessiondir}/vncserver.out"
 
     files_mark_tempfile "${sessiondir}/vncserver.out"

--- a/lib/functions/vnc.functions.sh
+++ b/lib/functions/vnc.functions.sh
@@ -67,7 +67,10 @@ vnc_start_server() {
     sessiondir="$2"
     shift 2
 
-    $cw_VNC_VNCSERVER -autokill \
+    # Set session geometry variable for VNC server process so the session
+    # scripts for session types which do not obey the VNC server's geometry
+    # parameter can be forced to resize to the given geometry.
+    cw_SESSION_geometry="${geometry}" $cw_VNC_VNCSERVER -autokill \
         -sessiondir "${sessiondir}" \
         -sessionscript "${sessiondir}/session.sh" \
         -vncpasswd "${sessiondir}/password.dat" \

--- a/libexec/session/actions/help
+++ b/libexec/session/actions/help
@@ -226,6 +226,10 @@ help_for_start() {
       the session will run up to the maximum runtime configured for
       this system (or forever if no maximum is configured).
 
+    --geometry <width>x<height>
+      Optionally specify a geometry to request for the VNC session,
+      overriding the Clusterware installation or VNC server default.
+
 EOF
 }
 

--- a/libexec/session/actions/start
+++ b/libexec/session/actions/start
@@ -79,7 +79,7 @@ main() {
     if ! session_check_quota; then
         action_die "sorry, your session quota has been reached on this host (${cw_SESSION_quota})."
     fi
-    local sessionscript password vnc_vars host_address terse params sessionvars sessiontype runtime
+    local sessionscript password vnc_vars host_address terse params sessionvars sessiontype runtime geometry
     local -A vnc
 
     #
@@ -103,6 +103,14 @@ main() {
         # enforce specified maximum
         runtime="${cw_SESSION_timeout}"
     fi
+
+    if [ "$1" == "--geometry" ]; then
+        # If no geometry is set we will end up passing "" through to the VNC
+        # server, and so the default value will be used.
+        geometry=$2
+        shift 2
+    fi
+    # TODO check format
 
     #
     # Determine session script to use.
@@ -158,7 +166,7 @@ EOF
     # Start session, logging/writing details.
     #
     password=$(vnc_create_password)
-    vnc_session_start "${password}" "${_SESSIONDIR}"
+    vnc_session_start "${password}" "${geometry}" "${_SESSIONDIR}"
 
     if ! vnc_vars="$(vnc_read_vars "${_SESSIONDIR}")"; then
         action_die "VNC server could not be started, unable to locate configuration file."

--- a/libexec/session/actions/start
+++ b/libexec/session/actions/start
@@ -105,11 +105,12 @@ main() {
     fi
 
     if [ "$1" == "--geometry" ]; then
-        # If no geometry is set we will end up passing "" through to the VNC
-        # server, and so the default value will be used.
         geometry=$2
         shift 2
     fi
+    # If no geometry is given as a parameter or in config, pass "" through to
+    # the VNC server so it uses its default value.
+    geometry="${geometry:-${cw_SESSION_geometry:-''}}"
     # TODO check format
 
     #

--- a/libexec/session/actions/start
+++ b/libexec/session/actions/start
@@ -110,8 +110,8 @@ main() {
     fi
     # If no geometry is given as a parameter or in config, pass "" through to
     # the VNC server so it uses its default value.
-    geometry="${geometry:-${cw_SESSION_geometry:-''}}"
-    if [[ ! "${geometry}" =~ ^[0-9]+x[0-9]+$ ]]; then
+    geometry="${geometry:-${cw_SESSION_geometry}}"
+    if [[ -n "${geometry}" && ! "${geometry}" =~ ^[0-9]+x[0-9]+$ ]]; then
         action_die "bad value for geometry: ${geometry} (must be like \"1024x768\")"
     fi
 

--- a/libexec/session/actions/start
+++ b/libexec/session/actions/start
@@ -81,10 +81,15 @@ main() {
     fi
     local sessionscript password vnc_vars host_address terse params sessionvars sessiontype runtime
     local -A vnc
+
+    #
+    # Optional argument parsing.
+    #
     if [ "$1" == "--terse" ]; then
         terse=true
         shift
     fi
+
     if [ "$1" == "--runtime" ]; then
         runtime=$2
         shift 2
@@ -99,6 +104,9 @@ main() {
         runtime="${cw_SESSION_timeout}"
     fi
 
+    #
+    # Determine session script to use.
+    #
     sessionscript="$1"
     shift
     if [ "$1" ]; then
@@ -128,6 +136,9 @@ main() {
     fi
     files_mark_tempfile "${_SESSIONDIR}/session.sh"
 
+    #
+    # Create wrapper script if needed to pass in extra parameters.
+    #
     if [ "$1" ]; then
         # we have parameters, so need to pass them into the session script
         mv "${_SESSIONDIR}/session.sh" "${_SESSIONDIR}/session-runner.sh"
@@ -143,6 +154,9 @@ exec ${_SESSIONDIR}/session-runner.sh ${params}
 EOF
     fi
 
+    #
+    # Start session, logging/writing details.
+    #
     password=$(vnc_create_password)
     vnc_session_start "${password}" "${_SESSIONDIR}"
 
@@ -183,6 +197,9 @@ EOF
         _start_timer "${vnc[DISPLAY]}" "${runtime}"
     fi
 
+    #
+    # Clean up.
+    #
     rm -f "${_SESSIONDIR}/starting.txt"
     {
         process_wait_for_pid $(cat "${vnc[PIDFILE]}")

--- a/libexec/session/actions/start
+++ b/libexec/session/actions/start
@@ -111,7 +111,9 @@ main() {
     # If no geometry is given as a parameter or in config, pass "" through to
     # the VNC server so it uses its default value.
     geometry="${geometry:-${cw_SESSION_geometry:-''}}"
-    # TODO check format
+    if [[ ! "${geometry}" =~ ^[0-9]+x[0-9]+$ ]]; then
+        action_die "bad value for geometry: ${geometry} (must be like \"1024x768\")"
+    fi
 
     #
     # Determine session script to use.


### PR DESCRIPTION
This PR allows specifying the geometry of sessions via a `--geometry` parameter or a config value `cw_SESSION_geometry` in `cw_ROOT/etc/session.rc`, as discussed in https://github.com/alces-software/clusterware/issues/85. It is based on https://github.com/alces-software/clusterware/pull/153.
