### PR TITLE
Running session screenshot handlers with correct data

### DIFF
--- a/libexec/session/share/grabber
+++ b/libexec/session/share/grabber
@@ -39,7 +39,14 @@ setup() {
 take_screenshot() {
     local display
     display=$1
-    xwd -root -silent -display :${display} | xwdtopnm | pnmtopng | base64
+
+    # Dump image of session X window.
+    xwd -root -silent -display ":${display}" | \
+
+        # Convert to base64-encoded PNG.
+        xwdtopnm | \
+        pnmtopng | \
+        base64
 }
 
 main() {

--- a/libexec/session/share/grabber
+++ b/libexec/session/share/grabber
@@ -63,7 +63,7 @@ main() {
     sleep 10
     while true; do
         action_warn "$(date --rfc-3339=seconds): Taking screenshot"
-        take_screenshot $display | handler_run_hook session-screenshot "$sessionid"
+        take_screenshot "$display" | handler_run_hook session-screenshot "$sessionid"
         sleep 60 &>/dev/null </dev/null &
         wait
     done

--- a/libexec/session/share/grabber
+++ b/libexec/session/share/grabber
@@ -46,12 +46,7 @@ take_screenshot() {
         # Convert to base64-encoded PNG.
         xwdtopnm | \
         pnmtopng | \
-        base64 | \
-
-        # Pipeline so far gives multiple whitespace-separated lines as output;
-        # convert to single line with internal whitespace stripped.
-        xargs | \
-        tr -d "[:space:]"
+        base64 -w0
 }
 
 main() {

--- a/libexec/session/share/grabber
+++ b/libexec/session/share/grabber
@@ -46,7 +46,12 @@ take_screenshot() {
         # Convert to base64-encoded PNG.
         xwdtopnm | \
         pnmtopng | \
-        base64
+        base64 | \
+
+        # Pipeline so far gives multiple whitespace-separated lines as output;
+        # convert to single line with internal whitespace stripped.
+        xargs | \
+        tr -d "[:space:]"
 }
 
 main() {

--- a/scripts/development/reconfigure
+++ b/scripts/development/reconfigure
@@ -28,9 +28,11 @@ fi
 # Script to help when developing Clusterware handlers - correctly set variables
 # below, add commits to given branches, and run this script to go through
 # motions of reconfiguring node (mostly) as if from scratch. You may still need
-# to remove handler-specific files if, remove serviceware dir if modifying
+# to remove handler-specific files, remove serviceware dir if modifying
 # serviceware, adapt this script sometimes etc.
 
+# TODO: Read these from environment variables rather than hard-coding, and
+# check they are set before proceeding.
 clusterware_services_branch='feature/add-slurm-serviceware'
 clusterware_handlers_branch='feature/cluster-slurm-handler'
 handler_name='cluster-slurm'
@@ -39,7 +41,7 @@ cw_ROOT='/opt/clusterware'
 ALCES="${cw_ROOT}/bin/alces"
 
 # Rerun handler installation.
-"$ALCES" handler disable cluster-slurm
+"$ALCES" handler disable "${handler_name}"
 
 # Ensure services will be re-enabled when needed.
 rm "${cw_ROOT}/etc/services/"*


### PR DESCRIPTION
This PR fixes an issue where session-screenshot handler hooks would be run many times with fragments of the overall screenshot data. The main fix is in https://github.com/alces-software/clusterware/commit/f814965f5202e6e463e3bd77bb10c3720f0973f8; also included are a couple of related commits.
