### PR TITLE
Added trap to kill spinner on interrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - The `alces configure` action has gained a `thp` operation for control of transparent hugepages behaviour
 - The Clusterware VPN IP address may optionally be added to DNS and as a SAN within the SSL certificate within a `.vpn` subdomain
 - Added `clocksource` as an option to `alces configure`. It modifies and displays the clocksource of the node.
+- Added a `trap` handler to `process.function.sh`
 
 ### Changed
 - Nothing yet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - The `alces configure` action has gained a `thp` operation for control of transparent hugepages behaviour
 - The Clusterware VPN IP address may optionally be added to DNS and as a SAN within the SSL certificate within a `.vpn` subdomain
 - Added `clocksource` as an option to `alces configure`. It modifies and displays the clocksource of the node.
-- Added a `trap` handler to `process.function.sh`
+- Signal trap handling added to the process function library
 
 ### Changed
 - Nothing yet
 
 ### Fixed
 - Correct autocompletion for `alces configure`
-- Prevents the `ui-spinner` from continuing on process interrupt
+- The progress spinner no longer continues spinning forever when the process receives an interrupt signal
 
 #### Issues/PRs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - The `alces configure` action has gained a `thp` operation for control of transparent hugepages behaviour
 - The Clusterware VPN IP address may optionally be added to DNS and as a SAN within the SSL certificate within a `.vpn` subdomain
 - Added `clocksource` as an option to `alces configure`. It modifies and displays the clocksource of the node.
-- Signal trap handling added to the process function library
+- Signal trap handling added to the `process` function library
 
 ### Changed
 - Nothing yet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Correct autocompletion for `alces configure`
+- Prevents the `ui-spinner` from continuing on process interrupt
 
 #### Issues/PRs
 

--- a/lib/functions/process.functions.sh
+++ b/lib/functions/process.functions.sh
@@ -98,7 +98,7 @@ process_trap_handle() {
   signal=$1
   trap_list_var="_PROCESS_${signal}"
   trap_exit_var="_PROCESS_EXIT_${signal}"
-  echo $(eval ${!trap_list_var})
+  ${!trap_list_var}
   if [ ${!trap_exit_var} -a ${!trap_exit_var} != "false" ]; then
     exit ${!trap_exit_var}
   fi

--- a/lib/functions/process.functions.sh
+++ b/lib/functions/process.functions.sh
@@ -115,10 +115,23 @@ process_trap_add() {
 # By default the trap does not exit
 # An exit_code of 'false' explicitly prevents the trap exiting
 process_trap_set_exit() { 
-  local signal=$1 exit_code=$2 trap_exit_var
-  shift 2
+  local force signal exit_code trap_exit_var
+  if [[ "$1" == "--force" ]]; then
+    force="true"
+    shift
+  fi
+  signal="$1"
+  if [[ -z "$2" ]]; then
+    exit_code=1
+  else
+    exit_code="$2"
+  fi
 
   trap_exit_var="_PROCESS_EXIT_${signal}"
+  if [[ -n "${!trap_exit_var}" && -z "$force" ]]; then
+    return 1
+  fi
+
   printf -v "$trap_exit_var" "$exit_code"
   trap "process_trap_handle $signal" $signal   
 }

--- a/lib/functions/ui.functions.sh
+++ b/lib/functions/ui.functions.sh
@@ -20,13 +20,13 @@
 # https://github.com/alces-software/clusterware
 #==============================================================================
 require action
+require process
 
 _ui_trap_sig() {
   if [ "$spin_pid" ]; then
-    kill $spin_pid
+    kill $spin_pid 2>/dev/null
     echo
   fi
-  exit 1
 }
 
 toggle_spin() {
@@ -45,7 +45,10 @@ toggle_spin() {
                 done
             ) &
             spin_pid=$!
-            trap _ui_trap_sig INT
+            process_trap_add INT '_ui_trap_sig'
+            if [ ! $(process_trap_get_exit INT) ]; then
+              process_trap_set_exit INT 1
+            fi
         else
             sleep 1
             kill $spin_pid

--- a/lib/functions/ui.functions.sh
+++ b/lib/functions/ui.functions.sh
@@ -21,6 +21,14 @@
 #==============================================================================
 require action
 
+_ui_trap_sig() {
+  if [ "$spin_pid" ]; then
+    kill $spin_pid
+    echo
+  fi
+  exit 1
+}
+
 toggle_spin() {
         if [ -z "$spin_pid" ]; then
             (
@@ -37,6 +45,7 @@ toggle_spin() {
                 done
             ) &
             spin_pid=$!
+            trap _ui_trap_sig INT
         else
             sleep 1
             kill $spin_pid

--- a/lib/functions/ui.functions.sh
+++ b/lib/functions/ui.functions.sh
@@ -22,7 +22,7 @@
 require action
 require process
 
-_ui_trap_sig() {
+_ui_spinner_kill() {
   if [ "$spin_pid" ]; then
     kill $spin_pid 2>/dev/null
     echo
@@ -45,8 +45,8 @@ toggle_spin() {
                 done
             ) &
             spin_pid=$!
-            process_trap_add INT '_ui_trap_sig'
-            if [ ! $(process_trap_get_exit INT) ]; then
+            process_trap_add INT _ui_spinner_kill
+            if ! process_trap_get_exit INT >/dev/null; then
               process_trap_set_exit INT 1
             fi
         else

--- a/lib/functions/ui.functions.sh
+++ b/lib/functions/ui.functions.sh
@@ -46,9 +46,7 @@ toggle_spin() {
             ) &
             spin_pid=$!
             process_trap_add INT _ui_spinner_kill
-            if ! process_trap_get_exit INT >/dev/null; then
-              process_trap_set_exit INT 1
-            fi
+            process_trap_set_exit INT
         else
             sleep 1
             kill $spin_pid


### PR DESCRIPTION
Added a trap to `ui.functions.sh` `toggle_spin` method to prevent the spinner from continuing after the calling script has terminated on interrupt. 

This fixes #219  where interrupting the synchronous script means the spinner continuous.